### PR TITLE
fix: fix scrollbox from preventing multiple clicks

### DIFF
--- a/components/modules/ScrollBox.tsx
+++ b/components/modules/ScrollBox.tsx
@@ -12,7 +12,8 @@ const ScrollBox = ({
   gap = 8,
   ...props
 }) => {
-  const [scrollInterval, setScrollInterval] = useState(null)
+  const [preventRightClick, setPreventRightClick] = useState(false)
+  const [preventLeftClick, setPreventLeftClick] = useState(false)
 
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const leftButtonRef = useRef<HTMLButtonElement>(null)
@@ -51,6 +52,7 @@ const ScrollBox = ({
   }
 
   const handleScrollRight = () => {
+    setPreventRightClick(true)
     const scrollContainer = scrollContainerRef.current
     scrollContainer.scrollTo({
       left: countScrollRight({
@@ -59,9 +61,13 @@ const ScrollBox = ({
       }),
       behavior: 'smooth',
     })
+    setTimeout(() => {
+      setPreventRightClick(false)
+    }, 300)
   }
 
   const handleScrollLeft = () => {
+    setPreventLeftClick(true)
     const scrollContainer = scrollContainerRef.current
     scrollContainer.scrollTo({
       left: countScrollLeft({
@@ -70,29 +76,21 @@ const ScrollBox = ({
       }),
       behavior: 'smooth',
     })
+    setTimeout(() => {
+      setPreventLeftClick(false)
+    }, 300)
   }
 
   const handleLeftButtonMouseDown = () => {
-    handleScrollLeft()
-    setScrollInterval(
-      setInterval(() => {
-        handleScrollLeft()
-      }, 10)
-    )
+    if (!preventLeftClick) {
+      handleScrollLeft()
+    }
   }
 
   const handleRightButtonMouseDown = () => {
-    handleScrollRight()
-    setScrollInterval(
-      setInterval(() => {
-        handleScrollRight()
-      }, 10)
-    )
-  }
-
-  const handleMouseUp = () => {
-    clearInterval(scrollInterval)
-    setScrollInterval(null)
+    if (!preventRightClick) {
+      handleScrollRight()
+    }
   }
 
   return (
@@ -117,8 +115,7 @@ const ScrollBox = ({
           variant={ButtonIconVariants.state2}
           mr={2}
           ref={leftButtonRef}
-          onMouseDown={handleLeftButtonMouseDown}
-          onMouseUp={handleMouseUp}
+          onClick={handleLeftButtonMouseDown}
         >
           <HiOutlineArrowLeft />
         </ButtonIcon>
@@ -126,8 +123,7 @@ const ScrollBox = ({
           aria-label="project-arrow-right"
           variant={ButtonIconVariants.state2}
           ref={rightButtonRef}
-          onMouseDown={handleRightButtonMouseDown}
-          onMouseUp={handleMouseUp}
+          onClick={handleRightButtonMouseDown}
         >
           <HiOutlineArrowRight />
         </ButtonIcon>

--- a/components/organisms/FloorPlanListing.tsx
+++ b/components/organisms/FloorPlanListing.tsx
@@ -21,23 +21,54 @@ const FloorList = ({ floor }) => {
     (state) => state?.pages[floorPlanRef]?.url
   )
 
-  const floorPlan = floor?.floorPlan?.listSizes[0]
+  const [images, setImages] = useState([])
+  const [floorIndex, setFloorIndex] = useState(null)
   const [slide, setSlide] = useState(0)
 
+  const floorPlan =
+    floorIndex !== null ? floor?.floorPlan?.listSizes[floorIndex] : []
+
   const handleNext = () => {
-    if (floorPlan?.listImages[slide + 1]?.image) {
+    if (slide === images.length - 1) {
+      setSlide(0)
+    } else {
       setSlide((count) => count + 1)
     }
   }
 
   const handlePrev = () => {
-    if (floorPlan?.listImages[slide - 1]?.image) {
+    if (slide === 0) {
+      setSlide(images.length - 1)
+    } else {
       setSlide((count) => count - 1)
     }
   }
 
-  return _.isArray(floorPlan?.listImages) &&
-    floorPlan?.listImages?.length > 0 ? (
+  useEffect(() => {
+    if (floor) {
+      const listSizes = floor?.floorPlan?.listSizes
+      for (let i = 0; i < listSizes?.length; i++) {
+        if (listSizes[i]?.listImages) {
+          const listImages = listSizes[i]?.listImages
+          let hasImages = []
+          for (let j = 0; j < listImages?.length; j++) {
+            if (listImages[j]?.image) {
+              hasImages.push(j)
+            }
+          }
+
+          if (!_.isEmpty(hasImages)) {
+            setImages(hasImages)
+            setFloorIndex(i)
+            setSlide(hasImages[0])
+            return
+          }
+        }
+      }
+    }
+  }, [floor])
+
+  return images?.length > 0 && floorIndex !== null ? (
     <>
       <Grid
         templateColumns={'repeat(6, 1fr)'}
@@ -52,6 +83,7 @@ const FloorList = ({ floor }) => {
             variant={ButtonIconVariants.state2}
             bg={'transparent'}
             onClick={handlePrev}
+            visibility={images.length < 2 ? 'hidden' : 'visible'}
           >
             <HiOutlineArrowLeft />
           </ButtonIcon>
@@ -63,15 +95,19 @@ const FloorList = ({ floor }) => {
           justifyContent={'center'}
         >
           {_.isArray(floorPlan?.listImages) &&
-            floorPlan?.listImages[slide]?.image && (
+            floorPlan?.listImages[images[slide]]?.image && (
               <Box mt={'32px'} textAlign={'center'}>
                 <Img
-                  src={urlForImage(floorPlan?.listImages[slide]?.image).url()}
+                  src={urlForImage(
+                    floorPlan?.listImages[images[slide]]?.image
+                  ).url()}
                   width={'202px'}
                   height={'446px'}
-                  alt={floorPlan?.listImages[slide]?.alt}
+                  alt={floorPlan?.listImages[images[slide]]?.alt}
                 />
-                <Text mb={'18px'}>{floorPlan?.listImages[slide]?.name}</Text>
+                <Text mb={'18px'}>
+                  {floorPlan?.listImages[images[slide]]?.name}
+                </Text>
               </Box>
             )}
         </GridItem>
@@ -81,6 +117,7 @@ const FloorList = ({ floor }) => {
             variant={ButtonIconVariants.state2}
             bg={'transparent'}
             onClick={handleNext}
+            visibility={images.length < 2 ? 'hidden' : 'visible'}
           >
             <HiOutlineArrowRight />
           </ButtonIcon>


### PR DESCRIPTION
- Fix scrollbox from preventing multiple clicks;
- FloorplanListing remove the button right and left while image only one;
- FloorplanListing next button go back to the first slide if it's the last slide;
- FloorplanListing prev button go back to the last slide if it's the first slide;
- FloorplanListing check if the floor hasn't images inside it, then change other floor.